### PR TITLE
Change Composer Name to match other public modules.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "onpayio/module-magento2-payment",
+    "name": "onpayio/magento2",
     "version": "1.0.0",
     "description": "OnPay Payment Method",
     "license": "MIT",


### PR DESCRIPTION
Other Packagist modules developed by OnPay follow a different naming convention, than was used during the development of the Magento2 Module. This PR aligns the naming.