### PR TITLE
DK1ONP1-5643 - small text mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Added SECURITY.md
+- Removed extra order text and added missing y
 
 ## [1.0.4] - 2024-10-16
 - Added general platform that identifies the plugin with the API.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -79,7 +79,7 @@
                     </field>
                 </group>
                 <group id="onpay_select" sortOrder="20" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
-                    <label>OnPay Select Pament Method</label>
+                    <label>OnPay Select Payment Method</label>
                     <field id="active" type="select" sortOrder="10" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
                         <label>Enabled</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/view/frontend/web/template/payment/onpay-select.html
+++ b/view/frontend/web/template/payment/onpay-select.html
@@ -57,7 +57,6 @@
                         "
                         disabled>
                     <span data-bind="i18n: 'Place Order'"></span>
-                    Order
                 </button>
             </div>
         </div>


### PR DESCRIPTION
Removed extra "order" text in Place Order button:
<img width="847" height="194" alt="Screenshot 2026-05-05 at 11 50 38" src="https://github.com/user-attachments/assets/1dedd893-9c62-43e5-bce8-da1083cb9ed8" />

Added missing "y" in Payment:
<img width="352" height="66" alt="Screenshot 2026-05-05 at 11 52 09" src="https://github.com/user-attachments/assets/913b1ae4-505d-4e08-8b53-0435a73fda9e" />
