### PR TITLE
DK1ONP1-5871 - Unauthenticated order cancellation in official Magento2 plugin

### DIFF
--- a/Controller/Callback/Index.php
+++ b/Controller/Callback/Index.php
@@ -76,7 +76,7 @@ class Index extends Action
             $logger->addWriter($writer);
             $logger->info('callback-accept');
         } else {
-            $response = $this->manageOnPay->decline($post);
+            $response = $this->manageOnPay->decline($post, true);
 
             $writer = new \Zend_Log_Writer_Stream(BP . '/var/log/callback-decline.log');
             $logger = new \Zend_Log();

--- a/Controller/Callback/Index.php
+++ b/Controller/Callback/Index.php
@@ -76,6 +76,7 @@ class Index extends Action
             $logger->addWriter($writer);
             $logger->info('callback-accept');
         } else {
+            // Server-to-server callback from OnPay; trust is established by HMAC verification inside decline().
             $response = $this->manageOnPay->decline($post, true);
 
             $writer = new \Zend_Log_Writer_Stream(BP . '/var/log/callback-decline.log');

--- a/Model/ManageOnPay.php
+++ b/Model/ManageOnPay.php
@@ -164,45 +164,70 @@ class ManageOnPay
      * Store Payment decline
      *
      * @param array $post all post values
+     * @param bool $trustedCallback true only when invoked from the server-to-server callback controller
      *
      * @return bool
      */
-    public function decline($post)
+    public function decline($post, $trustedCallback = false)
     {
-        $response = false;
+        $requestedIncrementId = isset($post['onpay_reference'])
+            ? (string) $post['onpay_reference']
+            : '';
 
-        if (intval($post['onpay_errorcode']) !== 0
-        ) {
-            $response = true;
-            $orderId = $post['onpay_reference'];
+        if ($trustedCallback) {
+            // Verify the HMAC signature of the callback payload.
+            $paymentWindow = new PaymentWindow();
+            $paymentWindow->setGatewayId($this->helper->getGatewayId());
+            $paymentWindow->setSecret($this->helper->getWindowSecret());
 
-            $order = $this
-                ->orderFactory
-                ->create();
-            $order->loadByIncrementId($orderId);
+            if (!$paymentWindow->validatePayment($post)) {
+                return false;
+            }
 
-            // Set Payment Additional Information
-            $this
-                ->updatePaymentAdditionalInformation(
-                    $post,
-                    $order->getPayment()
-                );
+            if (intval($post['onpay_errorcode']) === 0) {
+                return false;
+            }
+        } else {
+            // Match the requested order against the current checkout session.
+            $sessionIncrementId = (string) $this->checkoutSession->getLastRealOrderId();
 
-            $this->checkoutSession->restoreQuote();
-
-            // Add Comment
-            $order
-                ->addStatusHistoryComment(
-                    __("OnPay - Payment declined")
-                );
-            $order->save();
-
-            $this
-                ->orderManagement
-                ->cancel($order->getId());
+            if ($requestedIncrementId === '' || $sessionIncrementId === '' ||
+                $requestedIncrementId !== $sessionIncrementId
+            ) {
+                // Restore the quote so the customer can retry checkout.
+                $this->checkoutSession->restoreQuote();
+                return true;
+            }
         }
 
-        return $response;
+        $order = $this
+            ->orderFactory
+            ->create();
+        $order->loadByIncrementId($requestedIncrementId);
+
+        // Set Payment Additional Information
+        $this
+            ->updatePaymentAdditionalInformation(
+                $post,
+                $order->getPayment()
+            );
+
+        if (!$trustedCallback) {
+            $this->checkoutSession->restoreQuote();
+        }
+
+        // Add Comment
+        $order
+            ->addStatusHistoryComment(
+                __("OnPay - Payment declined")
+            );
+        $order->save();
+
+        $this
+            ->orderManagement
+            ->cancel($order->getId());
+
+        return true;
     }
 
     /**

--- a/Model/ManageOnPay.php
+++ b/Model/ManageOnPay.php
@@ -164,17 +164,17 @@ class ManageOnPay
      * Store Payment decline
      *
      * @param array $post all post values
-     * @param bool $trustedCallback true only when invoked from the server-to-server callback controller
+     * @param bool $verifyHmac when true, validate the payload's HMAC signature
      *
      * @return bool
      */
-    public function decline($post, $trustedCallback = false)
+    public function decline($post, $verifyHmac = false)
     {
         $requestedIncrementId = isset($post['onpay_reference'])
             ? (string) $post['onpay_reference']
             : '';
 
-        if ($trustedCallback) {
+        if ($verifyHmac) {
             // Verify the HMAC signature of the callback payload.
             $paymentWindow = new PaymentWindow();
             $paymentWindow->setGatewayId($this->helper->getGatewayId());
@@ -212,7 +212,7 @@ class ManageOnPay
                 $order->getPayment()
             );
 
-        if (!$trustedCallback) {
+        if (!$verifyHmac) {
             $this->checkoutSession->restoreQuote();
         }
 


### PR DESCRIPTION
## Summary

Fixes an unauthenticated CSRF that let any attacker cancel pending Magento orders paid via OnPay by hitting the decline or callback endpoints with just an error code and a guessable order reference. Reported by an external security researcher. Affects 1.0.0 through 1.0.5.

## Root cause and fix

The decline handler in the payment model accepted request parameters without any authenticity check and immediately called the Magento order cancel API. Both entry points were vulnerable: the browser-facing decline URL (unsigned by design) and the server-to-server callback (routed to the decline path when the OnPay transaction UUID was absent, still without validating the HMAC).

The decline method now takes a boolean flag indicating whether the caller is the trusted server-to-server callback. When true, it verifies the HMAC via the PaymentWindow validator and requires a non-zero error code before mutating anything. When false, it compares the incoming OnPay reference against the checkout session's last real order id and only proceeds if they match exactly; otherwise it restores the customer's quote and returns without touching order state. This preserves the legitimate customer-cancel flow while blocking attackers who have no matching session.

## Verification

Legit flow: place order, click cancel in the OnPay window, get redirected back, cart restored, decline message shown, order shows Canceled in admin with the "OnPay - Payment declined" comment.

Attack: unauthenticated curl against both entry points, plus one with a garbage HMAC, all against a pending test order. All three return HTTP 200 but the order stays in Pending Payment with no comment added. Before the fix, the same requests cancelled the order.

## Notes

The new parameter defaults to false, so callers using the old single-argument signature continue to work and take the safe branch.