### PR TITLE
DK1ONP1-5873 - Order is registered but transaction is not completed

### DIFF
--- a/Model/Payment/AbstractOnPayMethod.php
+++ b/Model/Payment/AbstractOnPayMethod.php
@@ -219,10 +219,10 @@ abstract class AbstractOnPayMethod extends AbstractMethod
                     $transaction->save();
                 }
             } catch (ValidatorException $ex) {
-                throw new ValidatorException($ex->getMessage());
+                throw new ValidatorException(__($ex->getMessage()));
             }
         } else {
-            throw new ValidatorException('Payment is not authorized.');
+            throw new ValidatorException(__('Payment is not authorized.'));
         }
         return $this;
     }
@@ -256,7 +256,7 @@ abstract class AbstractOnPayMethod extends AbstractMethod
             }
         }
 
-        throw new ValidatorException($message);
+        throw new ValidatorException(is_string($message) ? __($message) : $message);
     }
 
     /**
@@ -306,7 +306,7 @@ abstract class AbstractOnPayMethod extends AbstractMethod
             }
         }
 
-        throw new ValidatorException($message);
+        throw new ValidatorException(is_string($message) ? __($message) : $message);
     }
 
     /**

--- a/Test/Unit/Model/Payment/AbstractOnPayMethodTest.php
+++ b/Test/Unit/Model/Payment/AbstractOnPayMethodTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace OnPay\Magento2\Test\Unit\Model\Payment;
+
+use Magento\Framework\Validator\Exception as ValidatorException;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
+use OnPay\Magento2\Model\Payment\OnPayCardMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that capture, refund, cancel and void raise a
+ * ValidatorException with the expected message when the payment
+ * has no OnpayUUID (i.e. was never authorized at OnPay).
+ */
+class AbstractOnPayMethodTest extends TestCase
+{
+    /**
+     * Instantiate the payment method without invoking Magento's
+     * DI-heavy parent constructor.
+     */
+    private function newMethod(): OnPayCardMethod
+    {
+        return (new \ReflectionClass(OnPayCardMethod::class))
+            ->newInstanceWithoutConstructor();
+    }
+
+    private function newPaymentWithoutUuid(): Payment
+    {
+        $order = $this->createMock(Order::class);
+
+        $payment = $this->createMock(Payment::class);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getAdditionalInformation')->willReturn([]); // no OnpayUUID
+
+        return $payment;
+    }
+
+    public function testCaptureThrowsValidatorExceptionWithPhraseWhenOnpayUuidMissing(): void
+    {
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('Payment is not authorized.');
+
+        $this->newMethod()->capture($this->newPaymentWithoutUuid(), 10.00);
+    }
+
+    public function testRefundThrowsValidatorExceptionWithPhraseWhenOnpayUuidMissing(): void
+    {
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('refund');
+
+        $this->newMethod()->refund($this->newPaymentWithoutUuid(), 10.00);
+    }
+
+    public function testCancelThrowsValidatorExceptionWithPhraseWhenOnpayUuidMissing(): void
+    {
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('cancelled');
+
+        $this->newMethod()->cancel($this->newPaymentWithoutUuid());
+    }
+
+    public function testVoidThrowsValidatorExceptionWithPhraseWhenOnpayUuidMissing(): void
+    {
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('voided');
+
+        $this->newMethod()->void($this->newPaymentWithoutUuid());
+    }
+}

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+
+// vendor/onpayio/magento2/Test/bootstrap.php -> vendor/autoload.php
+require dirname(__DIR__, 3) . '/autoload.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="Test/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="OnPay Magento2 Unit Tests">
+            <directory>Test/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
ValidatorException requires a Phrase, not a string. Wrap string messages in __() in capture(), refund(), cancel() and void() so Magento shows the intended validation error instead of a fatal TypeError on 2.4.6+ / PHP 8.1+.

When submitting an invoice before the order is paid - Before:
<img width="1493" height="726" alt="Screenshot 2026-07-16 at 08 02 31" src="https://github.com/user-attachments/assets/8d4d2d35-4c6a-4a81-9960-4c7fe4c42835" />

When submitting an invoice before the order is paid - After:
<img width="1370" height="427" alt="Screenshot 2026-07-16 at 08 01 03" src="https://github.com/user-attachments/assets/1920cb03-af56-4018-ac28-5e28aa9171f1" />
