### PR TITLE
DK1ONP1-5871 - Unauthenticated order cancellation in official Magento2 plugin - part 2

### DIFF
--- a/Block/RedirectUrl.php
+++ b/Block/RedirectUrl.php
@@ -16,11 +16,9 @@
 
 namespace OnPay\Magento2\Block;
 
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Directory\Model\Region;
 use Magento\Directory\Model\RegionFactory;
-use Magento\Framework\Exception\InputException;
-use Magento\Framework\Stdlib\Cookie\FailureToSendException;
-use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Sales\Model\Order;
@@ -41,13 +39,15 @@ use Sokil\IsoCodes\Database\Countries;
 
 class RedirectUrl extends Template
 {
-    const COOKIE_ORDER_ID = 'onpay_order';
-    const COOKIE_DURATION = 120;
-
     /**
      * @var string|null
      */
     protected $incrementId;
+
+    /**
+     * @var CheckoutSession
+     */
+    protected $checkoutSession;
 
     /**
      * @var Config
@@ -63,11 +63,6 @@ class RedirectUrl extends Template
      * @var Countries
      */
     protected $isoCodesCountries;
-
-    /**
-     * @var CookieManagerInterface
-     */
-    protected $cookieManager;
 
     /**
      * @var OrderFactory
@@ -95,18 +90,18 @@ class RedirectUrl extends Template
     protected $onPayApi;
 
     /**
-     * @param Context                $context
-     * @param Config                 $helper
-     * @param CookieManagerInterface $cookieManager
-     * @param OrderFactory           $orderFactory
-     * @param Countries              $isoCodesCountries
-     * @param RegionFactory          $regionFactory
-     * @param ManageOnPay            $manageOnPay
+     * @param Context         $context
+     * @param Config          $helper
+     * @param CheckoutSession $checkoutSession
+     * @param OrderFactory    $orderFactory
+     * @param Countries       $isoCodesCountries
+     * @param RegionFactory   $regionFactory
+     * @param ManageOnPay     $manageOnPay
      */
     public function __construct(
         Context                     $context,
         Config                      $helper,
-        CookieManagerInterface      $cookieManager,
+        CheckoutSession             $checkoutSession,
         OrderFactory                $orderFactory,
         Countries                   $isoCodesCountries,
         RegionFactory               $regionFactory,
@@ -114,7 +109,7 @@ class RedirectUrl extends Template
     ) {
         parent::__construct($context);
         $this->helper = $helper;
-        $this->cookieManager = $cookieManager;
+        $this->checkoutSession = $checkoutSession;
         $this->orderFactory = $orderFactory;
         $this->isoCodesCountries = $isoCodesCountries;
         $this->regionFactory = $regionFactory;
@@ -133,30 +128,17 @@ class RedirectUrl extends Template
 
     /**
      * @return string|null
-     * @throws InputException
-     * @throws FailureToSendException
      */
     public function getOrderId()
     {
         if (null === $this->incrementId) {
-            $this->incrementId = $this->cookieManager->getCookie(self::COOKIE_ORDER_ID);
-            $this->deleteOrderCookie();
+            $this->incrementId = $this->checkoutSession->getLastRealOrderId();
         }
         return $this->incrementId;
     }
 
     /**
-     * @return void
-     * @throws InputException
-     * @throws FailureToSendException
-     */
-    private function deleteOrderCookie()
-    {
-        $this->cookieManager->deleteCookie(self::COOKIE_ORDER_ID);
-    }
-
-    /**
-     * @param  $orderId
+     * @param  string $orderId
      * @return Order
      */
     protected function getOrderDetails($orderId)
@@ -226,7 +208,16 @@ class RedirectUrl extends Template
 
         $order = $this->getOrderDetails($orderId);
 
+        // Only redirect fresh, pending OnPay orders
+        if (!$order->getId() || $order->getState() !== Order::STATE_NEW) {
+            return null;
+        }
+
         $payment = $order->getPayment();
+        if (null === $payment || 0 !== strpos((string) $payment->getMethod(), 'onpay_')) {
+            return null;
+        }
+
         if (null !== $payment->getLastTransId()) {
             //Cannot redirect: This order is already processed
             return null;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix TypeError when throwing ValidatorException with string message
 - Added unit tests for capture, refund, cancel and void
 - Validate HMAC and session on payment decline
+- Use checkout session for OnPay redirect order lookup
 
 ## [1.0.5] - 2026-06-11
 - Added SECURITY.md

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0"?>
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="sales_order_place_after">
-        <observer name="onpay_gateway_redirect" instance="OnPay\Magento2\Observer\SalesOrderPlaceAfter" />
-    </event>
 </config>


### PR DESCRIPTION
The `/onpay/redirect/window` page picked the order to process from a public `onpay_order` cookie, which anyone could set. That meant an attacker with a known/guessed pending order id could point the redirect at someone else's order and make the merchant backend create a new OnPay payment for it. 

This PR resolves the order from the checkout session instead (`$checkoutSession->getLastRealOrderId()`), so the cookie is no longer trusted. I also removed the observer that sets the cookie, so the whole mechanism is gone. 

**Extra guards in createPaymentWindow():** 
- order must exist and be in STATE_NEW 
- payment method must start with `onpay_` 

**Manually tested:** 
- Forged `onpay_order` cookie without a matching session -> "Could not get OrderID", no OnPay call, no writes to sales_order_payment. 
<img width="1499" height="419" alt="Screenshot 2026-07-29 at 13 28 15" src="https://github.com/user-attachments/assets/d766fb50-8775-4d6e-822a-0928b5942c6b" />

- Cross-session cookie swap -> browser gets redirected to its own session's order, not the forged one. 
- Normal checkout still redirects to OnPay as before.